### PR TITLE
plinkSTR speedups

### DIFF
--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -162,12 +162,14 @@ def LoadGT(record, sample_order, is_str=True, use_alt_num=-1, use_alt_length=-1,
                     sumAlleles = sum([int(int(item)==use_alt_num) for item in sample.gt_alleles])
                 except:
                     sumAlleles = 0
+                    exclude_samples.append(sample.sample)
                 gtdata[sample.sample] = sumAlleles
             elif use_alt_length >-1:
                 try:
                     sumAllelesLen = sum([int(len(alleles[int(item)])==use_alt_length) for item in sample.gt_alleles])
                 except:
                     sumAllelesLen = 0
+                    exclude_samples.append(sample.sample)
                 gtdata[sample.sample] = sumAllelesLen
             else:
                 try:

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -113,7 +113,7 @@ def PerformAssociation(data, covarcols, case_control=False, quant=True, minmaf=0
         return None # don't attempt regression
     if case_control:
         try:
-            pgclogit = sm.Logit(data["phenotype"], data[["GT"]+covarcols]).fit(disp=0, maxiter=maxiter) # not using formula api anymore, much faster!
+            pgclogit = sm.Logit(data["phenotype"], data[["intercept","GT"]+covarcols]).fit(disp=0, maxiter=maxiter) # not using formula api anymore, much faster!
             #pgclogit = logit(formula=formula, data=data[data["sample"].apply(lambda x: x not in exclude_samples)][["phenotype", "GT"]+covarcols]).fit(disp=0, maxiter=maxiter)
             #print pgclogit.summary() # TODO remove after debug
         except:

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -46,7 +46,7 @@ def LoadCondition(vcffile, condition, sample_order):
     region = "%s:%s-%s"%(chrom, start, int(start)+1)
     reader2.fetch(region)
     for record in reader2:
-        print record.start, int(start), record.ID
+        print(record.start, int(start), record.ID)
         if record.start==int(start):
             return LoadGT(record, sample_order, is_str=False)
     common.ERROR("Could not find SNP to condition on")

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -194,7 +194,8 @@ def RestrictSamples(data, samplefile, include=True):
     Output:
     - data (pd.DataFrame): modified dataframe
     """
-    samples = pd.read_csv(samplefile, names=["FID", "IID"])
+    samples = pd.read_csv(samplefile, names=["FID", "IID"], delim_whitespace=True)
+    samples = samples.applymap(str)
     if include:
         data = pd.merge(data, samples, on=["FID", "IID"])
     else:

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -159,7 +159,11 @@ def LoadGT(record, sample_order, is_str=True, use_alt_num=-1, use_alt_length=-1,
     afreqs = [(1-sum(record.aaf))]+record.aaf
     for sample in record:
         if not is_str: # Note, code opposite to match plink results
-            gtdata[sample.sample] = sum([1-int(item) for item in sample.gt_alleles])
+            try:
+                gtdata[sample.sample] = sum([1-int(item) for item in sample.gt_alleles])
+            except:
+                gtdata[sample.sample] = 0
+                exclude_samples.append(sample.sample)
         else:
             if use_alt_num > -1:
                 try:

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -104,6 +104,10 @@ def PerformAssociation(data, covarcols, case_control=False, quant=True, minmaf=0
     - assoc (dict). Returns association results. Return None on error
     """
     data = data[data["sample"].apply(lambda x: x not in exclude_samples)]
+
+    if data.shape[0] == 0:
+        return None
+
     assoc = {}
     formula = "phenotype ~ GT+"+"+".join(covarcols)
     maf = sum(data["GT"])*1.0/(2*data.shape[0])

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -113,7 +113,7 @@ def PerformAssociation(data, covarcols, case_control=False, quant=True, minmaf=0
         return None # don't attempt regression
     if case_control:
         try:
-            pgclogit = sm.Logit(data["phenotype"], data[["intercept","GT"]]).fit(disp=0, maxiter=maxiter) # not using formula api anymore, much faster!
+            pgclogit = sm.Logit(data["phenotype"], data[["GT"]+covarcols]).fit(disp=0, maxiter=maxiter) # not using formula api anymore, much faster!
             #pgclogit = logit(formula=formula, data=data[data["sample"].apply(lambda x: x not in exclude_samples)][["phenotype", "GT"]+covarcols]).fit(disp=0, maxiter=maxiter)
             #print pgclogit.summary() # TODO remove after debug
         except:

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -158,9 +158,17 @@ def LoadGT(record, sample_order, is_str=True, use_alt_num=-1, use_alt_length=-1,
             gtdata[sample.sample] = sum([1-int(item) for item in sample.gt_alleles])
         else:
             if use_alt_num > -1:
-                gtdata[sample.sample] = sum([int(int(item)==use_alt_num) for item in sample.gt_alleles])
+                try:
+                    sumAlleles = sum([int(int(item)==use_alt_num) for item in sample.gt_alleles])
+                except:
+                    sumAlleles = 0
+                gtdata[sample.sample] = sumAlleles
             elif use_alt_length >-1:
-                gtdata[sample.sample] = sum([int(len(alleles[int(item)])==use_alt_length) for item in sample.gt_alleles])
+                try:
+                    sumAllelesLen = sum([int(len(alleles[int(item)])==use_alt_length) for item in sample.gt_alleles])
+                except:
+                    sumAllelesLen = 0
+                gtdata[sample.sample] = sumAllelesLen
             else:
                 try:
                     f1, f2 = [afreqs[int(item)] for item in sample.gt_alleles]

--- a/plinkSTR/plinkSTR.py
+++ b/plinkSTR/plinkSTR.py
@@ -55,11 +55,11 @@ def GetAssocType(is_str, alt=-1, alt_len=-1, name=None):
     """
     Return string describing association type
     """
-    if not name is None: return name
     if not is_str: return "SNP"
     else:
-        if alt >= 0: return "STR-alt-%s"%alt
-        elif alt_len >= 0: return "STR-length-%s"%alt_len
+        if alt >= 0: return "%s-alt-%s"%(name,alt)
+        elif alt_len >= 0: return "%s-length-%s"%(name,alt_len)
+        elif not name is None: return name
         else: return "STR"
 
 def PrintHeader(outf, case_control=False, quant=True, comment_lines=[]):
@@ -372,13 +372,13 @@ def main():
                 gts, exclude_samples = LoadGT(record, sample_order, is_str=True, use_alt_num=i)
                 pdata["GT"] = gts
                 assoc = PerformAssociation(pdata, covarcols, case_control=args.logistic, quant=args.linear, exclude_samples=exclude_samples, maxiter=args.max_iter)
-                OutputAssoc(record.CHROM, record.POS, assoc, outf, assoc_type=GetAssocType(is_str, alt=alleles[i]))
+                OutputAssoc(record.CHROM, record.POS, assoc, outf, assoc_type=GetAssocType(is_str, alt=alleles[i], name=record.ID))
         if is_str and args.allele_tests_length:
             for length in set([len(record.REF)] + [len(alt) for alt in record.ALT]):
                 gts, exclude_samples = LoadGT(record, sample_order, is_str=True, use_alt_length=length)
                 pdata["GT"] = gts
                 assoc = PerformAssociation(pdata, covarcols, case_control=args.logistic, quant=args.linear, exclude_samples=exclude_samples, maxiter=args.max_iter)
-                OutputAssoc(record.CHROM, record.POS, assoc, outf, assoc_type=GetAssocType(is_str, alt_len=length))
+                OutputAssoc(record.CHROM, record.POS, assoc, outf, assoc_type=GetAssocType(is_str, alt_len=length, name=record.ID))
 
 if __name__ == "__main__":
     main()

--- a/plinkSTR/plinkSTR_clump.py
+++ b/plinkSTR/plinkSTR_clump.py
@@ -41,12 +41,13 @@ def main():
     parser.add_argument("--assoc", help="Association Results from plinkSTR", required=True, type=str)
     parser.add_argument("--vcf", help="VCF File", required=True, type=str)
     parser.add_argument("--out", help="Output file name. Default: stdout", required=False, type=str)
+    parser.add_argument("--region", help="Region", required=False, type=str)
     args = parser.parse_args()
 
     CLUMP_P1 = float(args.clump_p1)
     CLUMP_P2 = float(args.clump_p2)
     CLUMP_R2 = float(args.clump_r2)
-    CLUMP_KB = float(args.clump_kb)*1000
+    CLUMP_KB = int(args.clump_kb)*1000
 
     ASSOC_FILE = args.assoc
     VCF_FILE = args.vcf
@@ -59,10 +60,17 @@ def main():
 
     assoc_results = pd.read_csv(ASSOC_FILE, delim_whitespace=True)
     assoc_results['keep'] = 0
+    assoc_results['P'] = pd.to_numeric(assoc_results['P'],errors='coerce')
     assoc_results.loc[assoc_results['P'] < CLUMP_P2,'keep'] = 2
     assoc_results.loc[assoc_results['P'] < CLUMP_P1,'keep'] = 1
     assoc_results = assoc_results[assoc_results['keep']>0]
     assoc_results['keep'] = -1
+
+    if args.region:
+        region_chrom = int(args.region.split(":")[0])
+        assoc_results = assoc_results[assoc_results['CHROM'] == region_chrom]
+
+        ### implement position
 
     while(assoc_results[(assoc_results['keep']==-1)].shape[0]>0):
         strs_retain = []
@@ -74,12 +82,12 @@ def main():
         chrom = int(assoc_results[assoc_results['SNP']==index_str_id]['CHROM'])
         assoc_results.loc[assoc_results['SNP']==index_str_id,'keep'] = 1
 
-        start = (index_str_bp - CLUMP_KB/2)
-        end = (index_str_bp + CLUMP_KB/2)
+        start = int(index_str_bp - CLUMP_KB)
+        end = int(index_str_bp + CLUMP_KB)
         curr_assoc_results = assoc_results[(assoc_results['BP']>=start) & (assoc_results['BP']<=end) & (assoc_results['keep']==-1)]
         if curr_assoc_results.shape[0] == 0:
             #PrintLine('No STRs to clump with the index STR %d:%d'%(chrom,index_str_bp), outf)
-            PrintLine('%d %s %d %f %d NONE'%(chrom, index_str_id, index_str_bp, index_str_pmin, len(strs_discard)), outf)
+            PrintLine('%d %s %d %s %d NONE'%(chrom, index_str_id, index_str_bp, str(index_str_pmin), len(strs_discard)), outf)
             continue;
 
         assoc_ids = curr_assoc_results['SNP'].values.tolist()
@@ -97,26 +105,27 @@ def main():
         vcf = VCF(VCF_FILE)
         vcf_strids = []
         for v in vcf('%d:%d-%d'%(chrom,start,end)):
-            if len(v.REF) == 1:
+            if str(v.ID) == index_str_id:
                 continue
-            elif str(v.ID) == index_str_id:
-                continue
-            else:
-                str_gt = []
+	    else:
+		str_gt = []
                 gt_array = []
                 if str(v.ID) in assoc_ids:
-                    vcf_strids.append(str(v.ID))
-                    for gt in v.gt_bases:
-                        str_gt.append(np.sum([len(i)-len(v.REF) for i in gt.split("|")]))
-                    corr_matrix = np.corrcoef(str_gt,index_str_gt)[0,1] ** 2
-                    if corr_matrix <= CLUMP_R2:
-                        strs_retain.append(str(v.ID))
-                    else:
-                        strs_discard.append(str(v.ID))
+                    	vcf_strids.append(str(v.ID))
+                    	if CLUMP_R2 == 0:
+				strs_discard.append(str(v.ID))
+			else:
+				for gt in v.gt_bases:
+                        		str_gt.append(np.sum([len(i)-len(v.REF) for i in gt.split("|")]))
+                    		corr_matrix = np.corrcoef(str_gt,index_str_gt)[0,1] ** 2
+                    		if corr_matrix < CLUMP_R2:
+                        		strs_retain.append(str(v.ID))
+                    		else:
+                        		strs_discard.append(str(v.ID))
 
 
         assoc_results.loc[assoc_results['SNP'].isin(strs_discard),'keep'] = 0
-        PrintLine('%d %s %d %f %d %s'%(chrom, index_str_id, index_str_bp, index_str_pmin, len(strs_discard), ",".join(strs_discard)), outf)
+        PrintLine('%d %s %d %s %d %s'%(chrom, index_str_id, index_str_bp, str(index_str_pmin), len(strs_discard), ",".join(strs_discard)), outf)
 
 if __name__ == "__main__":
     main()

--- a/plinkSTR/plinkSTR_clump.py
+++ b/plinkSTR/plinkSTR_clump.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""
+
+Author: Shubham Saini
+shubhamsaini@eng.ucsd.edu
+
+
+Plink style LD-based clumping of GWAS results from plinkSTR
+Example:
+./clump.py --clump-p1 0.2 --clump-p2 0.2 --clump-r2 0.1 --clump-kb 3000 \
+--assoc /storage/s1saini/gwas_simu/results/assoc_output.100.assoc \
+--vcf /storage/s1saini/hipstr_allfilters/phased_feb18/hipstr.chr21.phased.vcf.gz
+
+"""
+
+
+import argparse
+import sys
+import numpy as np
+import pandas as pd
+from cyvcf2 import VCF
+
+def PrintLine(text, f):
+    f.write(text+"\n")
+    f.flush()
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+def main():
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("--clump-p1", help="Significance threshold for index SNPs", required=True, type=str)
+    parser.add_argument("--clump-p2", help="Secondary significance threshold for clumped SNPs", required=True, type=str)
+    parser.add_argument("--clump-r2", help="LD threshold for clumping", required=True, type=str)
+    parser.add_argument("--clump-kb", help="Physical distance threshold for clumping (kb)", required=True, type=str)
+    parser.add_argument("--assoc", help="Association Results from plinkSTR", required=True, type=str)
+    parser.add_argument("--vcf", help="VCF File", required=True, type=str)
+    parser.add_argument("--out", help="Output file name. Default: stdout", required=False, type=str)
+    args = parser.parse_args()
+
+    CLUMP_P1 = float(args.clump_p1)
+    CLUMP_P2 = float(args.clump_p2)
+    CLUMP_R2 = float(args.clump_r2)
+    CLUMP_KB = float(args.clump_kb)*1000
+
+    ASSOC_FILE = args.assoc
+    VCF_FILE = args.vcf
+
+    # Prepare output
+    if args.out: outf = open(args.out,"w")
+    else: outf = sys.stdout
+
+    PrintLine("CHR SNP BP P TOTAL SP2", outf)
+
+    assoc_results = pd.read_csv(ASSOC_FILE, delim_whitespace=True)
+    assoc_results['keep'] = 0
+    assoc_results.loc[assoc_results['P'] < CLUMP_P2,'keep'] = 2
+    assoc_results.loc[assoc_results['P'] < CLUMP_P1,'keep'] = 1
+    assoc_results = assoc_results[assoc_results['keep']>0]
+    assoc_results['keep'] = -1
+
+    while(assoc_results[(assoc_results['keep']==-1)].shape[0]>0):
+        strs_retain = []
+        strs_discard = []
+
+        index_str_pmin = np.min(assoc_results[assoc_results['keep']==-1]['P'])
+        index_str_id = assoc_results[(assoc_results['P']==index_str_pmin) & (assoc_results['keep']==-1)]['SNP'].values[0]
+        index_str_bp = int(assoc_results[assoc_results['SNP']==index_str_id]['BP'])
+        chrom = int(assoc_results[assoc_results['SNP']==index_str_id]['CHROM'])
+        assoc_results.loc[assoc_results['SNP']==index_str_id,'keep'] = 1
+
+        start = (index_str_bp - CLUMP_KB/2)
+        end = (index_str_bp + CLUMP_KB/2)
+        curr_assoc_results = assoc_results[(assoc_results['BP']>=start) & (assoc_results['BP']<=end) & (assoc_results['keep']==-1)]
+        if curr_assoc_results.shape[0] == 0:
+            #PrintLine('No STRs to clump with the index STR %d:%d'%(chrom,index_str_bp), outf)
+            PrintLine('%d %s %d %f %d NONE'%(chrom, index_str_id, index_str_bp, index_str_pmin, len(strs_discard)), outf)
+            continue;
+
+        assoc_ids = curr_assoc_results['SNP'].values.tolist()
+        vcf = VCF(VCF_FILE)
+        index_str_gt = []
+        for v in vcf('%d:%d-%d'%(chrom,index_str_bp,index_str_bp)):
+            if str(v.ID) != index_str_id:
+                #PrintLine('Index STR %s not found in VCF file'%(index_str_id), outf)
+                continue
+            str_gt = []
+            for gt in v.gt_bases:
+                str_gt.append(np.sum([len(i)-len(v.REF) for i in gt.split("|")]))
+            index_str_gt = str_gt
+
+        vcf = VCF(VCF_FILE)
+        vcf_strids = []
+        for v in vcf('%d:%d-%d'%(chrom,start,end)):
+            if len(v.REF) == 1:
+                continue
+            elif str(v.ID) == index_str_id:
+                continue
+            else:
+                str_gt = []
+                gt_array = []
+                if str(v.ID) in assoc_ids:
+                    vcf_strids.append(str(v.ID))
+                    for gt in v.gt_bases:
+                        str_gt.append(np.sum([len(i)-len(v.REF) for i in gt.split("|")]))
+                    corr_matrix = np.corrcoef(str_gt,index_str_gt)[0,1] ** 2
+                    if corr_matrix <= CLUMP_R2:
+                        strs_retain.append(str(v.ID))
+                    else:
+                        strs_discard.append(str(v.ID))
+
+
+        assoc_results.loc[assoc_results['SNP'].isin(strs_discard),'keep'] = 0
+        PrintLine('%d %s %d %f %d %s'%(chrom, index_str_id, index_str_bp, index_str_pmin, len(strs_discard), ",".join(strs_discard)), outf)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. statsmodels.formulas is inherently slow. Using traditional statsmodels.api is 3x faster
2. pdata now required "intercept" column for use with Logit.fit()